### PR TITLE
Check if buf is valid inside vim.schedule

### DIFF
--- a/lua/houdini.lua
+++ b/lua/houdini.lua
@@ -110,6 +110,9 @@ function M.setup(opts)
                         local buf = vim.api.nvim_get_current_buf()
                         -- schedule needed for the escape sequence to be completed properly
                         vim.schedule(function()
+                            if not vim.api.nvim_buf_is_valid(buf) then
+                                return
+                            end
                             local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
                             local content = table.concat(lines, '\n')
                             if content == unmodified_buf_content then


### PR DESCRIPTION
When a buffer get deleted on escape, then that buffer will not be valid and will throw an error

Error executing vim.schedule lua callback: .../aki/.local/share/nvim/lazy/houdini.nvim/lua/houdini.lua:113: Invalid buffer id: 3348 stack traceback:
	[C]: in function 'nvim_buf_get_lines'
	.../aki/.local/share/nvim/lazy/houdini.nvim/lua/houdini.lua:113: in function <.../aki/.local/share/nvim/lazy/houdini.nvim/lua/houdini.lua:112>