### PR TITLE
fix: prevent auto triggered escape sequence

### DIFF
--- a/lua/houdini.lua
+++ b/lua/houdini.lua
@@ -96,8 +96,8 @@ function M.setup(opts)
         if M.config.escape_sequences[mode] then
             if trigger_char and combinations[trigger_char][char] then
                 -- if the timer's due time is equal to the configured timeout its a sign that the escape sequence
-                -- was typed "automatically" (for example by `i_CTRL-A` or `i_CTRL-@`) and we should skip it
-                if timer and timer:get_due_in() == M.config.timeout then
+                -- was typed "automatically" (for example by `i_CTRL-A` or `i_CTRL-@`) and we should skip it (except its a macro)
+                if timer and timer:get_due_in() == M.config.timeout and vim.fn.reg_executing() == '' then
                     return
                 end
 

--- a/lua/houdini.lua
+++ b/lua/houdini.lua
@@ -95,6 +95,12 @@ function M.setup(opts)
         local mode = vim.api.nvim_get_mode().mode
         if M.config.escape_sequences[mode] then
             if trigger_char and combinations[trigger_char][char] then
+                -- if the timer's due time is equal to the configured timeout its a sign that the escape sequence
+                -- was typed "automatically" (for example by `i_CTRL-A` or `i_CTRL-@`) and we should skip it
+                if timer and timer:get_due_in() == M.config.timeout then
+                    return
+                end
+
                 local seq = M.config.escape_sequences[mode]
                 if type(seq) == 'function' then
                     seq = seq(trigger_char, char)


### PR DESCRIPTION
If the escape sequence was triggered withing 0 milliseconds the escape sequence was triggered automatically by i_CTRL-A or i_CTRL-@ and should be ignored. Fixes #3