### PR TITLE
Feat: new config option excluded_filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ require('houdini').setup {
     mappings = { 'jk' },
     timeout = vim.o.timeoutlen,
     check_modified = true,
+    excluded_filetypes = {},
     escape_sequences = {
         ['i']    = '<BS><BS><ESC>',
         ['ic']   = '<BS><BS><ESC>',

--- a/doc/houdini.txt
+++ b/doc/houdini.txt
@@ -69,6 +69,7 @@ initialize `houdini` with its default settings:
         mappings = { 'jk' },
         timeout = vim.o.timeoutlen,
         check_modified = true,
+        excluded_filetypes = {},
 		escape_sequences = {
 			['i']    = '<BS><BS><ESC>',
 			['ic']   = '<BS><BS><ESC>',
@@ -144,6 +145,12 @@ This feature will not do anything in the following cases:
 - the buffer was |modified| already before entering insert mode
 - you changed some text while entering insert mode using for example |S|, |C|
   or |o|
+
+------------------------------------------------------------------------------
+excluded_filetypes                                *houdini-excluded-filetypes*
+
+List of filetypes where houdini is not doing anything.
+Defaults to {} (no filetypes excluded).
 
 ------------------------------------------------------------------------------
 ESCAPE SEQUENCES                             *houdini-config-escape-sequences*

--- a/lua/houdini.lua
+++ b/lua/houdini.lua
@@ -8,6 +8,7 @@ local last_char = ''
 local last_mode = ''
 local last_tick = 0
 local last_cursor_pos = { 0, 0 }
+local excluded_filetypes_set = {}
 
 local ignore_key = vim.api.nvim_replace_termcodes('<Ignore>', true, true, true)
 
@@ -52,6 +53,7 @@ local defaults = {
     mappings = { 'jk' },
     timeout = vim.o.timeoutlen,
     check_modified = true,
+    excluded_filetypes = {},
     escape_sequences = {
         ['i']    = '<BS><BS><ESC>',        -- insert mode
         ['ic']   = '<BS><BS><ESC>',
@@ -114,6 +116,10 @@ function M.setup(opts)
     if opts then
         config = assert(vim.tbl_deep_extend('force', defaults, opts))
 
+        for _, excluded_filetype in ipairs(config.excluded_filetypes)  do
+            excluded_filetypes_set[excluded_filetype] = true
+        end
+
         -- check that all mappings are valid
         local mappings = vim.tbl_filter(function(m)
             local valid = #m == 2
@@ -167,6 +173,10 @@ function M.setup(opts)
         -- if no char was actually typed we abort to avoid setting the last_char and last_mode variables to "invalid" values
         if not char or char == '' then
             return
+        end
+
+        if excluded_filetypes_set[vim.bo.filetype] then
+          return
         end
 
         local mode = vim.api.nvim_get_mode().mode


### PR DESCRIPTION
Pretty self explanatory: an option to pass an array of filetypes that are ignored

Use case: I have a floating terminal for lazygit and I want to use jk to navigate in it not to exit terminal mode (I don't need that as I mapped q to exit the floating terminal for lazygit)